### PR TITLE
Make sure there is a focused thread before rendering todoist content

### DIFF
--- a/lib/my-message-sidebar.cjsx
+++ b/lib/my-message-sidebar.cjsx
@@ -60,7 +60,7 @@ class MyMessageSidebar extends React.Component
     </div>
 
   _renderAddToTodoist: =>
-
+    return <span /> unless @state.thread
     <div className="todoist-sidebar">
       <input className="textBox" type="text" value={@state.thread.subject}/>
       <div className="buttonFullWidth" onClick={@_addToTodoistPost}><p>Add to Todoist</p></div>


### PR DESCRIPTION
Prevents error when @state.thread is null